### PR TITLE
Move breakable block logic into an interface

### DIFF
--- a/Source/Actors/BreakBlock.cs
+++ b/Source/Actors/BreakBlock.cs
@@ -1,17 +1,19 @@
 ﻿
 namespace Celeste64;
 
-public class BreakBlock : Solid
+public class BreakBlock : Solid, IDashTrigger
 {
 	private static readonly string[] glassShards = ["shard_0", "shard_1", "shard_2"];
 	private static readonly string[] woodShards = ["wood_shard_0", "wood_shard_1", "wood_shard_2"];
-	
-	public readonly bool BouncesPlayer;
+
 	public readonly bool Secret;
 
-	public BreakBlock(bool bouncesPlayer, bool transparent, bool secret)
+    public bool BouncesPlayer => bouncesPlayer;
+    private readonly bool bouncesPlayer;
+
+	public BreakBlock(bool bouncesPlayer_, bool transparent, bool secret)
 	{
-		BouncesPlayer = bouncesPlayer;
+		bouncesPlayer = bouncesPlayer_;
 		Transparent = transparent;
 		Secret = secret;
 
@@ -19,7 +21,7 @@ public class BreakBlock : Solid
 			Model.Flags = ModelFlags.Transparent;
 	}
 
-	public void Break(Vec3 direction)
+    public void HandleDash(Vec3 velocity)
 	{
 		var size = LocalBounds.Size;
 		var amount = (size.X * size.Y * size.Z) / 200;
@@ -37,7 +39,7 @@ public class BreakBlock : Solid
 		{
 			var offset = new Vec3(World.Rng.Float(size.X), World.Rng.Float(size.Y), World.Rng.Float(size.Z));
 			var at = Vec3.Transform(offset - size / 2, Matrix);
-			var velocity = direction * World.Rng.Float(100, 400);
+			velocity = velocity.Normalized() * World.Rng.Float(100, 400);
 			World.Request<Debris>().Init(at, velocity, options[World.Rng.Int(options.Length)]);
 		}
 

--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -799,7 +799,7 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 				Audio.Play(Sfx.sfx_feather_state_bump_wall, Position);
 			}
 			// does it handle being dashed into?
-			else if (resolveImpact && hit.Actor is IDashTrigger trigger && velocity.XY().Length() > 90)
+			else if (resolveImpact && hit.Actor is IDashTrigger trigger && !hit.Actor.Destroying && velocity.XY().Length() > 90)
 			{
                 World.HitStun = 0.1f;
                 trigger.HandleDash(velocity);

--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -798,10 +798,21 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 				tFeatherWallBumpCooldown = 0.50f;
 				Audio.Play(Sfx.sfx_feather_state_bump_wall, Position);
 			}
-			// is it a breakable thing?
-			else if (resolveImpact && hit.Actor is BreakBlock breakable && !breakable.Destroying && velocity.XY().Length() > 90)
+			// does it handle being dashed into?
+			else if (resolveImpact && hit.Actor is IDashTrigger trigger && velocity.XY().Length() > 90)
 			{
-				BreakBlock(breakable, velocity.Normalized());
+                World.HitStun = 0.1f;
+                trigger.HandleDash(velocity);
+
+                if (trigger.BouncesPlayer)
+                {
+                    velocity.X = -velocity.X * 0.80f;
+                    velocity.Y = -velocity.Y * 0.80f;
+                    velocity.Z = 100;
+
+                    StateMachine.State = States.Normal;
+                    CancelGroundSnap();
+                }
 			}
 			// normal wall
 			else
@@ -1001,22 +1012,6 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 		}
 		else
 			return false;
-	}
-
-	private void BreakBlock(BreakBlock block, Vec3 direction)
-	{
-		World.HitStun = 0.1f;
-		block.Break(direction);
-
-		if (block.BouncesPlayer)
-		{
-			velocity.X = -velocity.X * 0.80f;
-			velocity.Y = -velocity.Y * 0.80f;
-			velocity.Z = 100;
-
-			StateMachine.State = States.Normal;
-			CancelGroundSnap();
-		}
 	}
 
 	internal void Spring(Spring spring)

--- a/Source/Interfaces.cs
+++ b/Source/Interfaces.cs
@@ -82,3 +82,12 @@ public interface ICastPointShadow
 {
 	public float PointShadowAlpha { get; set; }
 }
+
+/// <summary>
+/// Player searches for these and calls HandleDash if it collides at high velocity
+/// </summary>
+public interface IDashTrigger
+{
+    public bool BouncesPlayer { get; }
+    public void HandleDash(Vec3 velocity);
+}


### PR DESCRIPTION
Adds a new interface (`IDashTrigger`) for solid objects that want to handle being dashed into (breakable blocks, buttons, etc.)
Also reimplements `BreakBlock` using this interface.