### PR TITLE
Fix crash handler version

### DIFF
--- a/Celeste64Launcher/Program.cs
+++ b/Celeste64Launcher/Program.cs
@@ -43,6 +43,7 @@ class Program
 		const string ErrorFileName = "ErrorLog.txt";
 		StringBuilder error = new();
 		error.AppendLine($"Celeste 64 v.{Game.GameVersion.Major}.{Game.GameVersion.Minor}.{Game.GameVersion.Build}");
+		error.AppendLine($"Fuji v.{Game.LoaderVersion.Major}.{Game.LoaderVersion.Minor}.{Game.LoaderVersion.Build}");
 		error.AppendLine($"Error Log ({DateTime.Now})");
 		error.AppendLine($"Call Stack:");
 		error.AppendLine(e?.ToString() ?? string.Empty);

--- a/Celeste64Launcher/Program.cs
+++ b/Celeste64Launcher/Program.cs
@@ -42,7 +42,7 @@ class Program
 		// construct a log message
 		const string ErrorFileName = "ErrorLog.txt";
 		StringBuilder error = new();
-		error.AppendLine($"Celeste 64 v.{Game.LoaderVersion.Major}.{Game.LoaderVersion.Minor}.{Game.LoaderVersion.Build}");
+		error.AppendLine($"Celeste 64 v.{Game.GameVersion.Major}.{Game.GameVersion.Minor}.{Game.GameVersion.Build}");
 		error.AppendLine($"Error Log ({DateTime.Now})");
 		error.AppendLine($"Call Stack:");
 		error.AppendLine(e?.ToString() ?? string.Empty);


### PR DESCRIPTION
The crash handler incorrectly used the Fuji version instead of the Celeste64 version.
This PR will fix that and add the Fuji version to the crash logs.