### PR TITLE
Only hot-reload on known important files

### DIFF
--- a/Source/Data/Assets.cs
+++ b/Source/Data/Assets.cs
@@ -68,6 +68,8 @@ public static class Assets
 		var langs = new ConcurrentBag<(Language, GameMod)>();
 		var tasks = new List<Task>();
 
+		// NOTE: Make sure to update ModManager.OnModFileChanged() as well, for hot-reloading to work!
+		
 		var globalFs = ModManager.Instance.GlobalFilesystem;
 		foreach (var (file, mod) in globalFs.FindFilesInDirectoryRecursiveWithMod("Maps", "map"))
 		{

--- a/Source/ModManager.cs
+++ b/Source/ModManager.cs
@@ -105,7 +105,7 @@ public sealed class ModManager
 			    (dir.StartsWith("Skins") && extension == ".json") || // Skins/**.json
 			    (dir.StartsWith("DLLs") && extension is ".dll") || // DLLs/**.dll
 			    filepath == "Levels.json" ||			    
-			    filepath == "Fuji.json"))
+			    filepath == "Fuji.json")
 			{
 				Log.Info($"File Changed: {filepath} (From mod {ctx.Mod.ModInfo.Name}). Reloading assets.");
 			} 

--- a/Source/ModManager.cs
+++ b/Source/ModManager.cs
@@ -103,11 +103,9 @@ public sealed class ModManager
 			    (dir.StartsWith("Fonts") && extension is ".ttf" or ".otf") || // Fonts/**.ttf and Fonts/**.otf
 			    (dir.StartsWith("Sprites") && extension == ".png") || // Sprites/**.png
 			    (dir.StartsWith("Skins") && extension == ".json") || // Skins/**.json
-				(dir.StartsWith("DLLs") && extension is ".dll" or ".pdb") || // Skins/**.json
-			    filepath == "Levels.json" ||
-			    filepath == "Dialog.json" ||
-			    
-			    filepath.EndsWith("Fuji.json"))
+			    (dir.StartsWith("DLLs") && extension is ".dll") || // DLLs/**.dll
+			    filepath == "Levels.json" ||			    
+			    filepath == "Fuji.json"))
 			{
 				Log.Info($"File Changed: {filepath} (From mod {ctx.Mod.ModInfo.Name}). Reloading assets.");
 			} 

--- a/Source/ModManager.cs
+++ b/Source/ModManager.cs
@@ -4,16 +4,6 @@ namespace Celeste64;
 
 public sealed class ModManager
 {
-	// File extensions for which we shouldn't hot reload
-	private static readonly FrozenSet<string> HotReloadIgnoredExtensions = ((string[])[
-		".cs", ".csproj", ".sln", ".pdb", ".user" // C#/Rider related extensions
-	]).ToFrozenSet();
-	
-	// Top-level mod directories for which we shouldn't hot reload
-	private static readonly FrozenSet<string> HotReloadIgnoredFolders = ((string[])[
-		".idea", "bin", "obj", // C#/Rider related folders
-	]).ToFrozenSet();
-	
 	private ModManager() { }
 
 	private static ModManager? instance = null;
@@ -98,41 +88,34 @@ public sealed class ModManager
 	{
 		if (ctx.Path is { } filepath)
 		{
-			// Filter out paths that we should not reload assets for
-			// Sometimes, the asset watcher returns just the directory name instead of filename, so we have to handle that.
-			if (HotReloadIgnoredExtensions.Contains(Path.GetExtension(filepath)))
-			{
-				return;
-			}
-			
+			var extension = Path.GetExtension(filepath);
 			var dir = Path.GetDirectoryName(filepath) ?? "";
 			
-			// Filter out top-level directories we don't want
-			if (HotReloadIgnoredFolders.Contains(filepath))
+			// Important assets taken from Assets.Load()
+			// TODO: Support non-toplevel mods?
+			if ((dir.StartsWith("Maps") && extension == ".map" && !dir.StartsWith("Maps/autosave")) || // Maps/**.map except Maps/autosave/** 
+			    (dir.StartsWith("Textures") && extension == ".png") || // Textures/**.png
+			    (dir.StartsWith("Faces") && extension == ".png") || // Faces/**.png
+			    (dir.StartsWith("Models") && extension == ".glb") || // Models/**.glb
+			    (dir.StartsWith("Text") && extension == ".json") || // Text/**.json
+			    (dir.StartsWith("Audio") && extension == ".bank") || // Audio/**.bank
+			    (dir.StartsWith("Shaders") && extension == ".glsl") || // Shaders/**.glsl
+			    (dir.StartsWith("Fonts") && extension is ".ttf" or ".otf") || // Fonts/**.ttf and Fonts/**.otf
+			    (dir.StartsWith("Sprites") && extension == ".png") || // Sprites/**.png
+			    (dir.StartsWith("Skins") && extension == ".json") || // Skins/**.json
+				(dir.StartsWith("DLLs") && extension is ".dll" or ".pdb") || // Skins/**.json
+			    filepath == "Levels.json" ||
+			    filepath == "Dialog.json" ||
+			    
+			    filepath.EndsWith("Fuji.json"))
 			{
+				Log.Info($"File Changed: {filepath} (From mod {ctx.Mod.ModInfo?.Name}). Reloading assets.");
+			} 
+			else
+			{
+				// Unimportant file
 				return;
 			}
-			var firstSepIndex = filepath.IndexOfAny(['/', '\\']);
-			if (firstSepIndex != -1)
-			{
-				var topLevelFolder = dir[..firstSepIndex];
-				if (HotReloadIgnoredFolders.Contains(topLevelFolder))
-				{
-					return;
-				}
-			}
-
-			if (filepath.StartsWith("Maps", StringComparison.Ordinal))
-			{
-				// Ignore the autosave folder
-				if (dir.EndsWith("autosave", StringComparison.Ordinal)
-				    || filepath.EndsWith("autosave", StringComparison.Ordinal))
-				{
-					return;
-				}
-			}
-
-			Log.Info($"File Changed: {filepath} (From mod {ctx.Mod.ModInfo?.Name}). Reloading assets.");
 		}
 		else
 		{


### PR DESCRIPTION
Only watches the files which actually matter to the game. This of course creates the minor problem of having 2 places which need to be updated, but I doubt we're going to add so many new assets types that it'll become a problem.

In my opinion a whitelist is a better approach for this than updating a blacklist every time there is a new false-positive.

I assume this will need to be updated once non-toplevel mods are properly supported (with the `Fuji.json` requirement)