### PR TITLE
Small MonoMod fix

### DIFF
--- a/Source/Celeste64.csproj
+++ b/Source/Celeste64.csproj
@@ -23,9 +23,7 @@
         <PackageReference Include="MonoMod.RuntimeDetour" Version="25.1.0-prerelease.2"/>
         <PackageReference Include="ImGui.NET" Version="1.90.1.1"/>
 
-        <ProjectReference Include="..\Celeste64.HookGen\Celeste64.HookGen.csproj" OutputItemType="Analyzer">
-          <Private>false</Private>
-        </ProjectReference>
+        <ProjectReference Include="..\Celeste64.HookGen\Celeste64.HookGen.csproj" OutputItemType="Analyzer" Private="false" PrivateAssets="All" />
     </ItemGroup>
 
     <PropertyGroup Condition="($(RuntimeIdentifier) == '' and $([MSBuild]::IsOSPlatform('Linux'))) or $(RuntimeIdentifier.StartsWith('linux'))">

--- a/Source/Mod/Core/ModLoader.cs
+++ b/Source/Mod/Core/ModLoader.cs
@@ -256,7 +256,7 @@ public static class ModLoader
 
 		foreach (var (info, attr) in onHookMethods)
 		{
-			Log.Info($"Registering On-hook for method '{attr.Target}' in type '{attr.Target.DeclaringType}' with hook method '{info}'");
+			Log.Info($"Registering On-hook for method '{attr.Target}' in type '{attr.Target.DeclaringType}' with hook method '{info}' in type '{info.DeclaringType}'");
 			HookManager.Instance.RegisterHook(new Hook(attr.Target, info));
 		}
 		
@@ -268,7 +268,7 @@ public static class ModLoader
 
 		foreach (var (info, attr) in ilHookMethods)
 		{
-			Log.Info($"Registering IL-hook for method '{attr.Target}' in type '{attr.Target.DeclaringType}' with hook method '{info}'");
+			Log.Info($"Registering IL-hook for method '{attr.Target}' in type '{attr.Target.DeclaringType}' with hook method '{info}' in type '{info.DeclaringType}'");
 			HookManager.Instance.RegisterILHook(new ILHook(attr.Target, info.CreateDelegate<ILContext.Manipulator>()));
 		}
 	}

--- a/Source/Mod/Core/ModLoader.cs
+++ b/Source/Mod/Core/ModLoader.cs
@@ -268,7 +268,7 @@ public static class ModLoader
 		foreach (var (info, attr) in ilHookMethods)
 		{
 			Log.Info($"Registering IL-hook for method '{attr.Target}' in type '{attr.Target.DeclaringType}' with hook method '{info}'");
-			HookManager.Instance.RegisterHook(new Hook(attr.Target, info));
+			HookManager.Instance.RegisterILHook(new ILHook(attr.Target, info));
 		}
 	}
 }

--- a/Source/Mod/Core/ModLoader.cs
+++ b/Source/Mod/Core/ModLoader.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Text.Json;
+using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
 
 namespace Celeste64.Mod;
@@ -268,7 +269,7 @@ public static class ModLoader
 		foreach (var (info, attr) in ilHookMethods)
 		{
 			Log.Info($"Registering IL-hook for method '{attr.Target}' in type '{attr.Target.DeclaringType}' with hook method '{info}'");
-			HookManager.Instance.RegisterILHook(new ILHook(attr.Target, info));
+			HookManager.Instance.RegisterILHook(new ILHook(attr.Target, info.CreateDelegate<ILContext.Manipulator>()));
 		}
 	}
 }

--- a/Source/Mod/Hook/InternalHookGenTargetAttribute.cs
+++ b/Source/Mod/Hook/InternalHookGenTargetAttribute.cs
@@ -8,11 +8,11 @@ namespace Celeste64.Mod;
 [AttributeUsage(AttributeTargets.Method)]
 public class InternalOnHookGenTargetAttribute : Attribute
 {
-	internal MethodInfo Target = null!;
+	internal MethodBase Target = null!;
 }
 
 [AttributeUsage(AttributeTargets.Method)]
 public class InternalILHookGenTargetAttribute : Attribute
 {
-	internal MethodInfo Target = null!;
+	internal MethodBase Target = null!;
 }


### PR DESCRIPTION
Small fix, since i accidently used `Hook` instead of `ILHook`.
Also not properly privatizes HookGen, so that it's also not included when publishing the launcher.