### PR TITLE
Move localization handling to its own class

### DIFF
--- a/Source/Data/Language.cs
+++ b/Source/Data/Language.cs
@@ -157,6 +157,24 @@ public static class Loc
 	public static string ModStr(GameMod mod, string key) => Language.Current.GetModString(mod, key);
 	public static List<Language.Line> Lines(string key) => Language.Current.GetLines(key);
 	public static bool HasLines(string key) => Language.Current.Dialog.ContainsKey(key);
+
+	public class Localized(string key) {
+		protected string Key => key;
+		public override string ToString() {
+			return Str(key);
+		}
+
+		public static implicit operator Localized(string s) => new(s);
+		public static implicit operator string(Localized s) => s.ToString();
+	}
+
+	public class Unlocalized(string value) : Localized(value) {
+		public override string ToString() {
+			return Key;
+		}
+
+		public static explicit operator Unlocalized(string s) => new(s);
+	}
 }
 
 [JsonSourceGenerationOptions(

--- a/Source/Data/Language.cs
+++ b/Source/Data/Language.cs
@@ -158,9 +158,11 @@ public static class Loc
 	public static List<Language.Line> Lines(string key) => Language.Current.GetLines(key);
 	public static bool HasLines(string key) => Language.Current.Dialog.ContainsKey(key);
 
-	public class Localized(string key) {
+	public class Localized(string key) 
+	{
 		protected string Key => key;
-		public override string ToString() {
+		public override string ToString() 
+		{
 			return Str(key);
 		}
 
@@ -168,8 +170,10 @@ public static class Loc
 		public static implicit operator string(Localized s) => s.ToString();
 	}
 
-	public class Unlocalized(string value) : Localized(value) {
-		public override string ToString() {
+	public class Unlocalized(string value) : Localized(value) 
+	{
+		public override string ToString() 
+		{
 			return Key;
 		}
 

--- a/Source/Helpers/Menu.cs
+++ b/Source/Helpers/Menu.cs
@@ -16,14 +16,9 @@ public class Menu
 
 		public string Description { get; set; } = "";
 
-		public Item Describe(string description, bool localized = true)
+		public Item Describe(Loc.Localized description)
 		{
-			if (localized)
-			{
-				string localizedDescription = Loc.Str(description);
-				description = localizedDescription == "<MISSING>" ? description : localizedDescription;
-			}
-
+			
 			this.Description = description;
 
 			return this;
@@ -37,13 +32,8 @@ public class Menu
 		private readonly Menu? rootMenu;
 		public override string Label => label;
 
-		public Submenu(string label, Menu? rootMenu, Menu? submenu = null, bool localized = true)
+		public Submenu(Loc.Localized label, Menu? rootMenu, Menu? submenu = null)
 		{
-			if (localized)
-			{
-				string localizedLabel = Loc.Str(label);
-				label = localizedLabel == "<MISSING>" ? label : localizedLabel;
-			}
 			this.label = label;
 			this.rootMenu = rootMenu;
 			this.submenu = submenu;
@@ -76,13 +66,8 @@ public class Menu
 		private readonly Func<int> get;
 		private readonly Action<int> set;
 	
-		public Slider(string label, int min, int max, Func<int> get, Action<int> set, bool localized = true)
+		public Slider(Loc.Localized label, int min, int max, Func<int> get, Action<int> set)
 		{
-			if (localized)
-			{
-				string localizedLabel = Loc.Str(label);
-				label = localizedLabel == "<MISSING>" ? label : localizedLabel;
-			}
 			for (int i = 0, n = (max - min); i <= n; i ++)
 				labels.Add($"{label} [{new string('|', i)}{new string('.', n - i)}]");
 			this.min = min;
@@ -101,13 +86,8 @@ public class Menu
 		public override string Label => label;
 		public override bool Selectable { get; } = false;
 
-		public SubHeader(string label, bool localized = true)
+		public SubHeader(Loc.Localized label)
 		{
-			if (localized)
-			{
-				string localizedLabel = Loc.Str(label);
-				label = localizedLabel == "<MISSING>" ? label : localizedLabel;
-			}
 			this.label = label;
 		}
 	}
@@ -121,13 +101,8 @@ public class Menu
 		private readonly Func<List<string>> getLabels;
 		private readonly Action<string> set;
 
-		public OptionList(string label, Func<List<string>> getLabels, Func<string> get, Action<string> set, bool localized = true)
+		public OptionList(Loc.Localized label, Func<List<string>> getLabels, Func<string> get, Action<string> set)
 		{
-			if (localized)
-			{
-				string localizedLabel = Loc.Str(label);
-				label = localizedLabel == "<MISSING>" ? label : localizedLabel;
-			}
 			this.label = label;
 			this.getLabels = getLabels;
 			this.min = 0;
@@ -173,13 +148,8 @@ public class Menu
 		private readonly Action? action;
         public override string Label => label;
 
-		public Option(string label, Action? action = null, bool localized = true)
+		public Option(Loc.Localized label, Action? action = null)
 		{
-			if (localized)
-			{
-				string localizedLabel = Loc.Str(label);
-				label = localizedLabel == "<MISSING>" ? label : localizedLabel;
-			}
 			this.label = label;
 			this.action = action;
 		}
@@ -205,13 +175,8 @@ public class Menu
 
 		public override string Label => get() ? labelOn : labelOff;
 
-		public Toggle(string label, Action action, Func<bool> get, bool localized = true)
+		public Toggle(Loc.Localized label, Action action, Func<bool> get)
 		{
-			if (localized)
-			{
-				string localizedLabel = Loc.Str(label);
-				label = localizedLabel == "<MISSING>" ? label : localizedLabel;
-			}
 			labelOff = $"{label} : {Loc.Str("OptionsToggleOff")}";
 			labelOn = $"{label} :  {Loc.Str("OptionsToggleOn")}";
 			this.action = action;
@@ -237,13 +202,8 @@ public class Menu
 		private Func<int> get;
 		public override string Label => $"{label} : {options[get()]}";
 
-		public MultiSelect(string label, List<string> options, Func<int> get, Action<int> set, bool localized = true)
+		public MultiSelect(Loc.Localized label, List<string> options, Func<int> get, Action<int> set)
 		{
-			if (localized)
-			{
-				string localizedLabel = Loc.Str(label);
-				label = localizedLabel == "<MISSING>" ? label : localizedLabel;
-			}
 			this.label = label;
 			this.options = options;
 			this.get = get;
@@ -273,8 +233,8 @@ public class Menu
 			return list;
 		}
 
-		public MultiSelect(string label, Action<T> set, Func<T> get, bool localized = true)
-			: base(label, GetEnumOptions(), () => (int)(object)get(), (i) => set((T)(object)i), localized)
+		public MultiSelect(Loc.Localized label, Action<T> set, Func<T> get)
+			: base(label, GetEnumOptions(), () => (int)(object)get(), (i) => set((T)(object)i))
 		{
 
 		}

--- a/Source/Mod/Core/GameMod.cs
+++ b/Source/Mod/Core/GameMod.cs
@@ -284,7 +284,7 @@ public abstract class GameMod
 			if (propType.IsEnum)
 			{
 				newItem = new Menu.MultiSelect(
-					propName,
+					(Loc.Unlocalized)propName,
 					propType.GetEnumNames().ToList(),
 					() =>
 					{
@@ -297,8 +297,7 @@ public abstract class GameMod
 						object? newValue = propType.GetEnumValues().GetValue(value);
 						OnModSettingChanged(propName, newValue, changingNeedsReload);
 						prop.SetValue(instance, propType.GetEnumValues().GetValue(value));
-					},
-					false
+					}
 				);
 			}
 			else if (propType == typeof(int))
@@ -312,7 +311,7 @@ public abstract class GameMod
 					max = settingRangeAttribute.Max;
 				}
 				newItem = new Menu.Slider(
-					propName,
+					(Loc.Unlocalized)propName,
 					min,
 					max,
 					() => prop.GetValue(instance) as int? ?? 0,
@@ -320,21 +319,19 @@ public abstract class GameMod
 					{
 						OnModSettingChanged(propName, value, changingNeedsReload);
 						prop.SetValue(instance, value);
-					},
-					false
+					}
 				);
 			}
 			else if (propType == typeof(bool))
 			{
 				newItem = new Menu.Toggle(
-					propName,
+					(Loc.Unlocalized)propName,
 					() => {
 						bool newValue = !(prop.GetValue(instance) as bool? ?? false);
 						prop.SetValue(instance, newValue);
 						OnModSettingChanged(propName, newValue, changingNeedsReload);
 					},
-					() => prop.GetValue(instance) as bool? ?? false,
-					false
+					() => prop.GetValue(instance) as bool? ?? false
 				);
 			}
 			else if (prop.PropertyType.GetCustomAttribute<SettingSubMenuAttribute>() != null)
@@ -345,19 +342,17 @@ public abstract class GameMod
 					Menu subMenu = new Menu(menu.RootMenu);
 					subMenu.Title = propName;
 					AddMenuSettingsForType(subMenu, prop.PropertyType, value);
-					subMenu.Add(new Menu.Option("Back", () =>
-					{
-						if (menu != null)
+					subMenu.Add(new Menu.Option((Loc.Unlocalized)"Back", () =>
 						{
-							menu.PopRootSubMenu();
-						}
-					},
-					false));
+							if (menu != null)
+							{
+								menu.PopRootSubMenu();
+							}
+						}));
 					newItem = new Menu.Submenu(
-						propName,
+						(Loc.Unlocalized)propName,
 						menu.RootMenu,
-						subMenu,
-						false
+						subMenu
 					);
 				}
 			}
@@ -369,7 +364,7 @@ public abstract class GameMod
 				{
 					string localizedDescription = Loc.ModStr(this, propDescription);
 					propDescription = localizedDescription == "<MISSING>" ? propDescription : localizedDescription;
-					newItem.Describe(propDescription, false);
+					newItem.Describe((Loc.Unlocalized)propDescription);
 				}
 				menu.Add(newItem);
 			}


### PR DESCRIPTION
This abstracts localization handling from all the constructors of all the classes derived from `Item` to a single `Localized` class, the major benefit of this is code de-duplication. This does not require any changes from the user since `Localized` can be implicitly casted from string.
In order to re-introduce the ability to draw unlocalized strings to the screen a subclass of `Localized` was added which can also be casted from a string but it must be done explicitly: `(Unlocalized) "Hello, Fuji!"`, thus getting rid of any `localized = true` in the constructor parameters.