### PR TITLE
Fix some mod loading problems

### DIFF
--- a/Source/Game.cs
+++ b/Source/Game.cs
@@ -187,7 +187,6 @@ public class Game : Module
 		Log.Error("== ERROR ==\n\n" + e.ToString());
 		WriteToLog();
 		UnsafelySetScene(new GameErrorMessage(e));
-		return;
 	}
 
 	public override void Update()
@@ -255,9 +254,6 @@ public class Game : Module
 		}
 		else if (transitionStep == TransitionStep.Perform)
 		{
-			Scene? newScene = transition.Scene != null ? transition.Scene() : null;
-			if (Settings.EnableAdditionalLogging && newScene != null) Log.Info("Switching scene: " + newScene.GetType());
-
 			Audio.StopBus(Sfx.bus_gameplay_world, false);
 
 			// exit last scene
@@ -294,14 +290,14 @@ public class Game : Module
 			switch (transition.Mode)
 			{
 				case Transition.Modes.Replace:
-					Debug.Assert(newScene != null);
+					Debug.Assert(transition.Scene != null);
 					if (scenes.Count > 0)
 						scenes.Pop();
-					scenes.Push(newScene);
+					scenes.Push(transition.Scene());
 					break;
 				case Transition.Modes.Push:
-					Debug.Assert(newScene != null);
-					scenes.Push(newScene);
+					Debug.Assert(transition.Scene != null);
+					scenes.Push(transition.Scene());
 					audioBeatCounter = 0;
 					break;
 				case Transition.Modes.Pop:
@@ -312,6 +308,8 @@ public class Game : Module
 			// run a single update when transition happens so stuff gets established
 			if (scenes.TryPeek(out var nextScene))
 			{
+				if (Settings.EnableAdditionalLogging) Log.Info("Switching scene: " + nextScene.GetType());
+				
 				try
 				{
 					nextScene.Entered();

--- a/Source/Mod/Core/GameMod.cs
+++ b/Source/Mod/Core/GameMod.cs
@@ -508,10 +508,10 @@ public abstract class GameMod
 
 
 	// Passthrough functions to simplify adding Hooks to the Hook Manager.
-	public static void RegisterHook(Hook hook) => HookManager.Instance.RegisterHook(hook);
-	public static void RegisterILHook(ILHook iLHook) => HookManager.Instance.RegisterILHook(iLHook);
-	public static void RemoveHook(Hook hook) => HookManager.Instance.RemoveHook(hook);
-	public static void RemoveILHook(ILHook iLHook) => HookManager.Instance.RemoveILHook(iLHook);
+	public void RegisterHook(Hook hook) => HookManager.Instance.RegisterHook(hook, ModInfo);
+	public void RegisterILHook(ILHook iLHook) => HookManager.Instance.RegisterILHook(iLHook, ModInfo);
+	public void DeregisterHook(Hook hook) => HookManager.Instance.DeregisterHook(hook, ModInfo);
+	public void DeregisterILHook(ILHook iLHook) => HookManager.Instance.DeregisterILHook(iLHook, ModInfo);
 
 	/// <summary>
 	/// Registers the provided custom player state,

--- a/Source/Mod/Core/ModLoader.cs
+++ b/Source/Mod/Core/ModLoader.cs
@@ -151,13 +151,24 @@ public static class ModLoader
 				{
 					var mod = LoadGameMod(info, fs);
 					mod.Filesystem?.AssociateWithMod(mod);
-					ModManager.Instance.RegisterMod(mod);
-
-					// Load hooks after the mod has been registered
-					foreach (var type in mod.GetType().Assembly.GetTypes())
+					
+					try
 					{
-						FindAndRegisterHooks(type);
+						ModManager.Instance.RegisterMod(mod);
+
+						// Load hooks after the mod has been registered
+						foreach (var type in mod.GetType().Assembly.GetTypes())
+						{
+							FindAndRegisterHooks(type);
+						}
 					}
+					catch
+					{
+						// Perform cleanup
+						ModManager.Instance.DeregisterMod(mod);
+						throw;
+					}
+					
 					loaded.Add(info);
 					loadedModInIteration = true;
 				}

--- a/Source/Mod/Core/ModLoader.cs
+++ b/Source/Mod/Core/ModLoader.cs
@@ -318,8 +318,6 @@ public static class ModLoader
 			
 			foreach (var (info, attr) in onHookMethods)
 			{
-				Log.Info($"Registering On-hook for method '{attr.Target}' in type '{attr.Target.DeclaringType}' with hook method '{info}' in type '{info.DeclaringType}'");
-			
 				var onHook = new Hook(attr.Target, info);
 				hooks.Add(onHook);
 				HookManager.Instance.RegisterHook(onHook);
@@ -333,8 +331,6 @@ public static class ModLoader
 			
 			foreach (var (info, attr) in ilHookMethods)
 			{
-				Log.Info($"Registering IL-hook for method '{attr.Target}' in type '{attr.Target.DeclaringType}' with hook method '{info}' in type '{info.DeclaringType}'");
-			
 				var ilHook = new ILHook(attr.Target, info.CreateDelegate<ILContext.Manipulator>());
 				hooks.Add(ilHook);
 				HookManager.Instance.RegisterILHook(ilHook);

--- a/Source/Mod/Core/ModLoader.cs
+++ b/Source/Mod/Core/ModLoader.cs
@@ -159,13 +159,14 @@ public static class ModLoader
 						// Load hooks after the mod has been registered
 						foreach (var type in mod.GetType().Assembly.GetTypes())
 						{
-							FindAndRegisterHooks(type);
+							FindAndRegisterHooks(info, type);
 						}
 					}
 					catch
 					{
 						// Perform cleanup
 						ModManager.Instance.DeregisterMod(mod);
+						HookManager.Instance.ClearHooksOfMod(info);
 						throw;
 					}
 					
@@ -315,7 +316,7 @@ public static class ModLoader
 		return loadedMod;
 	}
 
-	private static void FindAndRegisterHooks(Type type)
+	private static void FindAndRegisterHooks(ModInfo modInfo, Type type)
 	{
 		List<IDisposable> hooks = [];
 		
@@ -331,7 +332,7 @@ public static class ModLoader
 			{
 				var onHook = new Hook(attr.Target, info);
 				hooks.Add(onHook);
-				HookManager.Instance.RegisterHook(onHook);
+				HookManager.Instance.RegisterHook(onHook, modInfo);
 			}
 			
 			// IL. hooks
@@ -344,7 +345,7 @@ public static class ModLoader
 			{
 				var ilHook = new ILHook(attr.Target, info.CreateDelegate<ILContext.Manipulator>());
 				hooks.Add(ilHook);
-				HookManager.Instance.RegisterILHook(ilHook);
+				HookManager.Instance.RegisterILHook(ilHook, modInfo);
 			}
 		}
 		catch

--- a/Source/Mod/Hook/HookManager.cs
+++ b/Source/Mod/Hook/HookManager.cs
@@ -57,7 +57,10 @@ public sealed class HookManager
 			Log.Info($"Registering On-hook for method '{hook.Source}' in type '{hook.Source.DeclaringType}' with hook method '{hook.Target}' in type '{hook.Target.DeclaringType}' for mod '{mod.Id}'");
 		
 		if (!hooksByMod.TryGetValue(mod.Id, out var hooks))
+		{
 			hooks = [];
+			hooksByMod.Add(mod.Id, hooks);
+		}
 		hooks.Add(hook);
 	}
 	public void RegisterILHook(ILHook ilHook, ModInfo mod)
@@ -66,7 +69,10 @@ public sealed class HookManager
 			Log.Info($"Registering IL-hook for method '{ilHook.Method}' in type '{ilHook.Method.DeclaringType}' with hook method '{ilHook.Manipulator.Method}' in type '{ilHook.Manipulator.Method.DeclaringType}' for mod '{mod.Id}'");
 			
 		if (!ilHooksByMod.TryGetValue(mod.Id, out var ilHooks))
+		{
 			ilHooks = [];
+			ilHooksByMod.Add(mod.Id, ilHooks);
+		}
 		ilHooks.Add(ilHook);
 	}
 

--- a/Source/Mod/Hook/HookManager.cs
+++ b/Source/Mod/Hook/HookManager.cs
@@ -9,59 +9,149 @@ public sealed class HookManager
 	public static HookManager Instance => instance ??= new HookManager();
 	private static HookManager? instance = null;
 
-	private readonly List<Hook> hooks = [];
-	private readonly List<ILHook> ilHooks = [];
+	private readonly Dictionary<string, List<Hook>> hooksByMod = [];
+	private readonly Dictionary<string, List<ILHook>> ilHooksByMod = [];
 
-	public void RegisterHook(Hook? hook)
+	public void RegisterHook(Hook hook)
 	{
-		if (hook != null)
+		var mod = ModAssemblyLoadContext.GetInfoForCallingAssembly();
+		if (mod == null)
 		{
-			Log.Info($"{Settings.EnableAdditionalLogging}");
-			if (Settings.EnableAdditionalLogging)
-				Log.Info($"Registering On-hook for method '{hook.Source}' in type '{hook.Source.DeclaringType}' with hook method '{hook.Target}' in type '{hook.Target.DeclaringType}'");
-			
-			hooks.Add(hook);
+			if (hook != null)
+				Log.Warning($"Failed to identify mod trying to register On-hook for method '{hook.Source}' in type '{hook.Source.DeclaringType}' with hook method '{hook.Target}' in type '{hook.Target.DeclaringType}'");
+			else
+				Log.Warning($"Failed to identify mod trying to register a null On-hook");
+			return;
 		}
+		if (hook == null)
+		{
+			Log.Warning($"Mod '{mod.Id}' tried to register a null On-hook");
+			return;
+		}
+			
+		RegisterHook(hook, mod);
+	}
+	public void RegisterILHook(ILHook ilHook)
+	{
+		var mod = ModAssemblyLoadContext.GetInfoForCallingAssembly();
+		if (mod == null)
+		{
+			if (ilHook != null)
+				Log.Warning($"Failed to identify mod trying to register IL-hook for method '{ilHook.Method}' in type '{ilHook.Method.DeclaringType}' with hook method '{ilHook.Manipulator.Method}' in type '{ilHook.Manipulator.Method.DeclaringType}'");
+			else
+				Log.Warning($"Failed to identify mod trying to register a null IL-hook");
+			return;
+		}
+		if (ilHook == null)
+		{
+			Log.Warning($"Mod '{mod.Id}' tried to register a null IL-hook");
+			return;
+		}
+		
+		RegisterILHook(ilHook, mod);
+	}
+	
+	public void RegisterHook(Hook hook, ModInfo mod)
+	{
+		if (Settings.EnableAdditionalLogging)
+			Log.Info($"Registering On-hook for method '{hook.Source}' in type '{hook.Source.DeclaringType}' with hook method '{hook.Target}' in type '{hook.Target.DeclaringType}' for mod '{mod.Id}'");
+		
+		if (!hooksByMod.TryGetValue(mod.Id, out var hooks))
+			hooks = [];
+		hooks.Add(hook);
+	}
+	public void RegisterILHook(ILHook ilHook, ModInfo mod)
+	{
+		if (Settings.EnableAdditionalLogging)
+			Log.Info($"Registering IL-hook for method '{ilHook.Method}' in type '{ilHook.Method.DeclaringType}' with hook method '{ilHook.Manipulator.Method}' in type '{ilHook.Manipulator.Method.DeclaringType}' for mod '{mod.Id}'");
+			
+		if (!ilHooksByMod.TryGetValue(mod.Id, out var ilHooks))
+			ilHooks = [];
+		ilHooks.Add(ilHook);
 	}
 
-	public void RegisterILHook(ILHook? ilHook)
+	public void DeregisterHook(Hook hook)
 	{
-		if (ilHook != null)
+		var mod = ModAssemblyLoadContext.GetInfoForCallingAssembly();
+		if (mod == null)
 		{
-			if (Settings.EnableAdditionalLogging)
-				Log.Info($"Registering IL-hook for method '{ilHook.Method}' in type '{ilHook.Method.DeclaringType}' with hook method '{ilHook.Manipulator.Method}' in type '{ilHook.Manipulator.Method.DeclaringType}'");
-			
-			ilHooks.Add(ilHook);
+			if (hook != null)
+				Log.Warning($"Failed to identify mod trying to deregister On-hook for method '{hook.Source}' in type '{hook.Source.DeclaringType}' with hook method '{hook.Target}' in type '{hook.Target.DeclaringType}'");
+			else
+				Log.Warning($"Failed to identify mod trying to deregister a null On-hook");
+			return;
 		}
-	}
-
-	public void RemoveHook(Hook? hook)
-	{
-		if (hook != null)
+		if (hook == null)
 		{
+			Log.Warning($"Mod '{mod.Id}' tried to deregister a null On-hook");
+			return;
+		}
+		
+		DeregisterHook(hook, mod);
+	}
+	public void DeregisterILHook(ILHook ilHook)
+	{
+		var mod = ModAssemblyLoadContext.GetInfoForCallingAssembly();
+		if (mod == null)
+		{
+			if (ilHook != null)
+				Log.Warning($"Failed to identify mod trying to deregister IL-hook for method '{ilHook.Method}' in type '{ilHook.Method.DeclaringType}' with hook method '{ilHook.Manipulator.Method}' in type '{ilHook.Manipulator.Method.DeclaringType}'");
+			else
+				Log.Warning($"Failed to identify mod trying to deregister a null IL-hook");
+			return;
+		}
+		if (ilHook == null)
+		{
+			Log.Warning($"Mod '{mod.Id}' tried to deregister a null IL-hook");
+			return;
+		}
+		
+		DeregisterILHook(ilHook, mod);
+	}
+	
+	public void DeregisterHook(Hook hook, ModInfo mod)
+	{
+		hook.Dispose();
+		if (hooksByMod.TryGetValue(mod.Id, out var hooks))
 			hooks.Remove(hook);
-		}
 	}
-
-	public void RemoveILHook(ILHook? ilHook)
+	public void DeregisterILHook(ILHook ilHook, ModInfo mod)
 	{
-		if (ilHook != null)
-		{
+		ilHook.Dispose();
+		if (ilHooksByMod.TryGetValue(mod.Id, out var ilHooks))
 			ilHooks.Remove(ilHook);
+	}
+	
+	internal void ClearHooksOfMod(ModInfo mod)
+	{
+		if (hooksByMod.Remove(mod.Id, out var hooks))
+		{
+			foreach (var hook in hooks)
+			{
+				hook.Dispose();
+			}
+		}
+		
+		if (ilHooksByMod.Remove(mod.Id, out var ilHooks))
+		{
+			foreach (var ilHook in ilHooks)
+			{
+				ilHook.Dispose();
+			}
 		}
 	}
 
 	internal void ClearHooks()
 	{
-		foreach (var hook in hooks)
+		foreach (var hook in hooksByMod.Values.SelectMany(static hooks => hooks))
 		{
 			hook.Dispose();
 		}
-		foreach (var hook in ilHooks)
+		foreach (var ilHook in ilHooksByMod.Values.SelectMany(static ilHooks => ilHooks))
 		{
-			hook.Dispose();
+			ilHook.Dispose();
 		}
-		hooks.Clear();
-		ilHooks.Clear();
+		hooksByMod.Clear();
+		ilHooksByMod.Clear();
 	}
 }

--- a/Source/Mod/Hook/HookManager.cs
+++ b/Source/Mod/Hook/HookManager.cs
@@ -16,6 +16,10 @@ public sealed class HookManager
 	{
 		if (hook != null)
 		{
+			Log.Info($"{Settings.EnableAdditionalLogging}");
+			if (Settings.EnableAdditionalLogging)
+				Log.Info($"Registering On-hook for method '{hook.Source}' in type '{hook.Source.DeclaringType}' with hook method '{hook.Target}' in type '{hook.Target.DeclaringType}'");
+			
 			hooks.Add(hook);
 		}
 	}
@@ -24,6 +28,9 @@ public sealed class HookManager
 	{
 		if (ilHook != null)
 		{
+			if (Settings.EnableAdditionalLogging)
+				Log.Info($"Registering IL-hook for method '{ilHook.Method}' in type '{ilHook.Method.DeclaringType}' with hook method '{ilHook.Manipulator.Method}' in type '{ilHook.Manipulator.Method.DeclaringType}'");
+			
 			ilHooks.Add(ilHook);
 		}
 	}


### PR DESCRIPTION
Fixes the scene being created before a reload and various issues to hooks persisting.
Contains a minor breaking change with `RemoveHook` -> `DeregisterHook`. I don't think anyone was using that anyway so it should be fine.
Also the passthourgh methods in the GameMod are no longer static. That might affect some people, idk. Can be added back as obsolete for now an removed in 0.7.0 if needed.