### PR TITLE
Hair Color Enhancements

### DIFF
--- a/Mods/DefaultSkins/Skins/badeline.json
+++ b/Mods/DefaultSkins/Skins/badeline.json
@@ -2,9 +2,9 @@
     "Model": "badeline",
     "HideHair": false,
     "Name": "Badeline",
-    "HairNormal" : 10174389,
-    "HairNoDash" : 7258367,
-    "HairTwoDash" : 16421375,
-    "HairRefillFlash" : 16777215,
-    "HairFeather" : 15914064
+    "HairNormal" : "9B3FB5",
+    "HairNoDash" : "6EC0FF",
+    "HairTwoDash" : "FA91FF",
+    "HairRefillFlash" : "FFFFFF",
+    "HairFeather" : "F2D450"
 }

--- a/Mods/DefaultSkins/Skins/granny.json
+++ b/Mods/DefaultSkins/Skins/granny.json
@@ -2,9 +2,9 @@
     "Model": "granny",
     "HideHair": true,
     "Name": "Granny",
-    "HairNormal" : 16777215,
-    "HairNoDash" : 7258367,
-    "HairTwoDash" : 16421375,
-    "HairRefillFlash" : 16777215,
-    "HairFeather" : 15914064
+    "HairNormal" : "FFFFFF",
+    "HairNoDash" : "6EC0FF",
+    "HairTwoDash" : "FA91FF",
+    "HairRefillFlash" : "FFFFFF",
+    "HairFeather" : "F2D450"
 }

--- a/Mods/DefaultSkins/Skins/player-short-hair.json
+++ b/Mods/DefaultSkins/Skins/player-short-hair.json
@@ -1,10 +1,5 @@
 {
     "Model": "player",
     "HideHair": true,
-    "Name": "Short Hair",
-    "HairNormal" : 14363648,
-    "HairNoDash" : 7258367,
-    "HairTwoDash" : 16421375,
-    "HairRefillFlash" : 16777215,
-    "HairFeather" : 15914064
+    "Name": "Short Hair"
 }

--- a/Mods/DefaultSkins/Skins/theo.json
+++ b/Mods/DefaultSkins/Skins/theo.json
@@ -2,9 +2,5 @@
     "Model": "theo",
     "HideHair": true,
     "Name": "Theo",
-    "HairNormal" : 4530968,
-    "HairNoDash" : 7258367,
-    "HairTwoDash" : 16421375,
-    "HairRefillFlash" : 16777215,
-    "HairFeather" : 15914064
+    "HairNormal" : "452318"
 }

--- a/Source/Mod/Helpers/SkinInfo.cs
+++ b/Source/Mod/Helpers/SkinInfo.cs
@@ -1,4 +1,5 @@
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Celeste64;
@@ -12,11 +13,18 @@ public class SkinInfo
 	public virtual string Model { get; set; } = "";
 	public virtual bool HideHair { get; set; } = false;
 	public virtual string CollectableId { get; set; } = "";
-	public virtual int HairNormal { get; set; } = 0;
-	public virtual int HairNoDash { get; set; } = 0;
-	public virtual int HairTwoDash { get; set; } = 0;
-	public virtual int HairRefillFlash { get; set; } = 0;
-	public virtual int HairFeather { get; set; } = 0;
+
+	[JsonConverter(typeof(DecimalOrHexConverter))]
+	public virtual int HairNormal { get; set; } = 0xdb2c00;
+	[JsonConverter(typeof(DecimalOrHexConverter))]
+	public virtual int HairNoDash { get; set; } = 0x6ec0ff;
+	[JsonConverter(typeof(DecimalOrHexConverter))]
+	public virtual int HairTwoDash { get; set; } = 0xfa91ff;
+	[JsonConverter(typeof(DecimalOrHexConverter))]
+	public virtual int HairRefillFlash { get; set; } = 0xffffff;
+	[JsonConverter(typeof(DecimalOrHexConverter))]
+	public virtual int HairFeather { get; set; } = 0xf2d450;
+
 
 	public bool IsValid()
 	{
@@ -30,6 +38,39 @@ public class SkinInfo
 
 	public virtual void OnEquipped(Player player, Model m) { }
 	public virtual void OnRemoved(Player player, Model m) { }
+}
+
+// This allows us to support either decimal integers or hex strings.
+public class DecimalOrHexConverter : JsonConverter<int>
+{
+	public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		if (reader.TokenType == JsonTokenType.Number)
+		{
+			return reader.TryGetInt32(out var i) ? i : 0;
+		}
+		else if (reader.TokenType == JsonTokenType.String)
+		{
+			try
+			{
+				return Convert.ToInt32(reader.GetString(), 16);
+			}
+			catch (Exception ex)
+			{
+				Log.Error("Error: Could not parse value in skin file: " + ex.ToString());
+				return 0;
+			}
+		}
+		else
+		{
+			return 0;
+		}
+	}
+
+	public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+	{
+		JsonSerializer.Serialize(writer, value, value.GetType());
+	}
 }
 
 [JsonSourceGenerationOptions(WriteIndented = true)]

--- a/Source/Mod/Helpers/SkinInfo.cs
+++ b/Source/Mod/Helpers/SkinInfo.cs
@@ -25,7 +25,6 @@ public class SkinInfo
 	[JsonConverter(typeof(DecimalOrHexConverter))]
 	public virtual int HairFeather { get; set; } = 0xf2d450;
 
-
 	public bool IsValid()
 	{
 		return !string.IsNullOrEmpty(Name) && !string.IsNullOrEmpty(Model);


### PR DESCRIPTION
This change updates how we handle Hair Colors to now allow support for Hex strings, instead of only decimal ints. This should simplify how colors are entered for strings in most cases. It's set up in a way that either format is supported, so we shouldn't be breaking compatibility with existing skins.
I also updated the default values so they now will default to madeline's colors by default, instead of defaulting to black. This means that colors will now be optional, and you should only need to change hair colors that actually are different than the default. Technically, this could cause a breaking change if anyone was expecting it to be default and have black hair, but none of the released skin mods seem to be doing that, so I think that we're probably in the clear.
I also updated the default skins to now use hex instead, since I assume that will now become the preferred way of doing it, and those are probably going to be seen as an example by modders. For Badeline and Granny, I filled out all the colors, even though I probably didn't need to, just so they could be used as examples by modders. We can maybe revisit this when we have a proper skin template repo though.