### PR TITLE
Logging improvements

### DIFF
--- a/Source/Helpers/LogHelper.cs
+++ b/Source/Helpers/LogHelper.cs
@@ -16,7 +16,7 @@ public static class LogHelper
 		Error,
 		Verbose
 	}
-	
+
 	private const string LogFileName = "Log.txt";
 
 	private static string? _logPath;
@@ -40,7 +40,7 @@ public static class LogHelper
 
 	// This should never be accessed directly
 	private static readonly LoggerWriter Logs = new(true);
-	
+
 	/*
 	 A simple Assembly.GetCallingAssembly() is not good enough for our needs here. 
 	 We need to travel up the stack to get the actual assembly name.
@@ -109,7 +109,7 @@ public static class LogHelper
 	}
 
 	/// <summary>
-	/// TextWritter wrapper to facilitate and guarantee tread safety.
+	/// TextWriter wrapper to facilitate and guarantee thread safety.
 	/// </summary>
 	private class LoggerWriter
 	{
@@ -138,7 +138,7 @@ public static class LogHelper
 		private readonly StreamWriter bufferStreamWriter;
 
 		private TextWriter CurrentBuffer => TextWriter ?? bufferStreamWriter;
-		
+
 		public LoggerWriter(bool flushAutomatically)
 		{
 			bufferStreamWriter = new StreamWriter(new MemoryStream());


### PR DESCRIPTION
Cleans up the logger by making it so it uses a stdlib thread-safe `TextWritter`, and buffers data before the log path is known (because currently logs will be written to two different locations: the runtime dir and the actual user path dir).

This approach should be more performant as well.